### PR TITLE
pashov audit fixes [L-04]

### DIFF
--- a/script/deploy/deploy-crosschain/DeployCrossChainOP.s.sol
+++ b/script/deploy/deploy-crosschain/DeployCrossChainOP.s.sol
@@ -4,10 +4,12 @@ pragma solidity 0.8.21;
 import {DeployCrossChainBase, CrossChainOPTellerWithMultiAssetSupport} from "./DeployCrossChainBase.s.sol";
 import {console} from "forge-std/Test.sol";
 // import {console2} from "";
+
 contract DeployCrossChainOP is DeployCrossChainBase {
 
     address constant SEPOLIA_OPT_MESSENGER = 0x4200000000000000000000000000000000000007;
     uint32 constant SEPOLIA_OPT_CHAIN_ID = 11155420;
+    uint8 public constant OP_MESSENGER_ROLE = 5;
 
     // address constant SEI_DEVNET = 0x6EDCE65403992e310A62460808c4b910D972f10f; 
     // uint32 constant SEI_DEVNET_SELECTOR = 713715;
@@ -16,6 +18,7 @@ contract DeployCrossChainOP is DeployCrossChainBase {
     uint32 constant SEPOLIA_MAIN_CHAIN_ID = 11155111;
 
     function run() external{
+
         addressesByRpc["sepolia_main"]["WETH"] = 0x5f207d42F869fd1c71d7f0f81a2A67Fc20FF7323;
         addressesByRpc["op_sepolia"]["WETH"] = 0x4200000000000000000000000000000000000006;
 
@@ -28,12 +31,20 @@ contract DeployCrossChainOP is DeployCrossChainBase {
         // this needs to be done here, and not later because foundry will wipe the state when broadcast is stopped.
         main.addChain(SEPOLIA_OPT_CHAIN_ID, true, true, address(main), 100_000);
 
+        // give manager the ability to call the receive message function
+        rolesAuthority.setRoleCapability(OP_MESSENGER_ROLE, address(main), CrossChainOPTellerWithMultiAssetSupport.receiveBridgeMessage.selector, true);
+        rolesAuthority.setUserRole(SEPOLIA_MAIN_MESSENGER, OP_MESSENGER_ROLE, true);
+
         vm.stopBroadcast();
 
         vm.createSelectFork(vm.rpcUrl("op_sepolia"));
         vm.startBroadcast();
         CrossChainOPTellerWithMultiAssetSupport op = fullDeployForChainOP("op_sepolia", SEPOLIA_OPT_MESSENGER);
         op.addChain(SEPOLIA_MAIN_CHAIN_ID, true, true, address(main), 100_000);
+
+        // give manager the ability to call the receive message function
+        rolesAuthority.setRoleCapability(OP_MESSENGER_ROLE, address(op), CrossChainOPTellerWithMultiAssetSupport.receiveBridgeMessage.selector, true);
+        rolesAuthority.setUserRole(SEPOLIA_OPT_MESSENGER, OP_MESSENGER_ROLE, true);
         vm.stopBroadcast();
     }
 

--- a/src/base/Roles/CrossChain/CrossChainOPTellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/CrossChain/CrossChainOPTellerWithMultiAssetSupport.sol
@@ -65,15 +65,13 @@ contract CrossChainOPTellerWithMultiAssetSupport is CrossChainTellerBase {
     }
 
     /**
+     * @dev it's recommended that this function uses a check that msg.sender == messenger by OP, however, to keep with stanadard we are instead 
+     * using Auth to set the messenger as the only accepted caller of this function
      * @notice Function for OP Messenger to call to receive a message and mint the shares on this chain
      * @param receiver to receive the shares
      * @param shareMintAmount amount of shares to mint
      */
-    function receiveBridgeMessage(address receiver, uint256 shareMintAmount) external{
-
-        if(msg.sender != address(messenger)){
-            revert CrossChainOPTellerWithMultiAssetSupport_OnlyMessenger();
-        }
+    function receiveBridgeMessage(address receiver, uint256 shareMintAmount) external requiresAuth{
 
         if(messenger.xDomainMessageSender() != peer){
             revert CrossChainOPTellerWithMultiAssetSupport_OnlyPeerAsSender();

--- a/src/base/Roles/CrossChain/CrossChainTellerBase.sol
+++ b/src/base/Roles/CrossChain/CrossChainTellerBase.sol
@@ -128,7 +128,7 @@ abstract contract CrossChainTellerBase is ICrossChainTeller, TellerWithMultiAsse
      * @param minimumMint minimum required shares to receive
      * @param data Bridge Data
      */
-    function depositAndBridge(ERC20 depositAsset, uint256 depositAmount, uint256 minimumMint, BridgeData calldata data) external payable{
+    function depositAndBridge(ERC20 depositAsset, uint256 depositAmount, uint256 minimumMint, BridgeData calldata data) external payable requiresAuth{
         uint shareAmount = _erc20Deposit(depositAsset, depositAmount, minimumMint, msg.sender);
         bridge(shareAmount, data);
     }
@@ -150,7 +150,7 @@ abstract contract CrossChainTellerBase is ICrossChainTeller, TellerWithMultiAsse
      * @param shareAmount to bridge
      * @param data bridge data
      */
-    function bridge(uint256 shareAmount, BridgeData calldata data) public payable returns(bytes32 messageId){
+    function bridge(uint256 shareAmount, BridgeData calldata data) public payable requiresAuth returns(bytes32 messageId){
         if(isPaused) revert TellerWithMultiAssetSupport__Paused();
         if(!selectorToChains[data.chainSelector].allowMessagesTo) revert CrossChainTellerBase_MessagesNotAllowedTo(data.chainSelector);
         

--- a/src/base/Roles/CrossChain/CrossChainTellerBase.sol
+++ b/src/base/Roles/CrossChain/CrossChainTellerBase.sol
@@ -128,7 +128,7 @@ abstract contract CrossChainTellerBase is ICrossChainTeller, TellerWithMultiAsse
      * @param minimumMint minimum required shares to receive
      * @param data Bridge Data
      */
-    function depositAndBridge(ERC20 depositAsset, uint256 depositAmount, uint256 minimumMint, BridgeData calldata data) external payable requiresAuth{
+    function depositAndBridge(ERC20 depositAsset, uint256 depositAmount, uint256 minimumMint, BridgeData calldata data) external payable requiresAuth nonReentrant{
         uint shareAmount = _erc20Deposit(depositAsset, depositAmount, minimumMint, msg.sender);
         bridge(shareAmount, data);
     }

--- a/test/CrossChain/CrossChainBase.t.sol
+++ b/test/CrossChain/CrossChainBase.t.sol
@@ -40,8 +40,7 @@ abstract contract CrossChainBaseTest is Test, MainnetAddresses {
     CrossChainTellerBase sourceTeller;
     CrossChainTellerBase destinationTeller;
 
-    function _deploySourceAndDestinationTeller() internal virtual{
-    }
+    function _deploySourceAndDestinationTeller() internal virtual {}
 
     function setUp() public virtual{
         // Setup forked environment.
@@ -54,10 +53,11 @@ abstract contract CrossChainBaseTest is Test, MainnetAddresses {
         accountant = new AccountantWithRateProviders(
             address(this), address(boringVault), payout_address, 1e18, address(WETH), 1.001e4, 0.999e4, 1, 0
         );
+    
+        rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
+
 
         _deploySourceAndDestinationTeller();
-
-        rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
 
         boringVault.setAuthority(rolesAuthority);
         accountant.setAuthority(rolesAuthority);
@@ -93,6 +93,11 @@ abstract contract CrossChainBaseTest is Test, MainnetAddresses {
         rolesAuthority.setPublicCapability(
             address(destinationTeller), TellerWithMultiAssetSupport.depositWithPermit.selector, true
         );
+
+        rolesAuthority.setPublicCapability(address(sourceTeller), CrossChainTellerBase.bridge.selector, true);
+        rolesAuthority.setPublicCapability(address(destinationTeller), CrossChainTellerBase.bridge.selector, true);
+        rolesAuthority.setPublicCapability(address(sourceTeller), CrossChainTellerBase.depositAndBridge.selector, true);
+        rolesAuthority.setPublicCapability(address(destinationTeller), CrossChainTellerBase.depositAndBridge.selector, true);
 
         rolesAuthority.setUserRole(address(sourceTeller), MINTER_ROLE, true);
         rolesAuthority.setUserRole(address(sourceTeller), BURNER_ROLE, true);


### PR DESCRIPTION
Added requires Auth to all non-view external functions and the non-reenterant to depositAndBridge

Worth noting that I had to change the auth for deployment scripts which I have not tried to deploymyself.

And that now for OP bridge we have to give the `OP_MESSENGER_ROLE` (5) to the messenger so that it can call `receiveBridgeMessage` instead of using the msg.sender check it had before